### PR TITLE
[Fix] 온보딩 백버튼 이동시 데이터 유지 관련 수정

### DIFF
--- a/Hamsters/Hamsters.xcodeproj/project.pbxproj
+++ b/Hamsters/Hamsters.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		305240162ADD73EB008FCD14 /* UserDefaultsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305240132ADD73EB008FCD14 /* UserDefaultsKey.swift */; };
 		305240172ADD73EB008FCD14 /* SmokingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305240142ADD73EB008FCD14 /* SmokingStatus.swift */; };
 		305240182ADD73EB008FCD14 /* SexClassification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305240152ADD73EB008FCD14 /* SexClassification.swift */; };
+		3052401A2ADE1299008FCD14 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305240192ADE1299008FCD14 /* String+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -47,6 +48,7 @@
 		305240132ADD73EB008FCD14 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		305240142ADD73EB008FCD14 /* SmokingStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SmokingStatus.swift; sourceTree = "<group>"; };
 		305240152ADD73EB008FCD14 /* SexClassification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SexClassification.swift; sourceTree = "<group>"; };
+		305240192ADE1299008FCD14 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				304180EE2ADBB37B002AD2E3 /* View+.swift */,
+				305240192ADE1299008FCD14 /* String+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -241,6 +244,7 @@
 				305240162ADD73EB008FCD14 /* UserDefaultsKey.swift in Sources */,
 				304180D12ADA8E37002AD2E3 /* HamstersApp.swift in Sources */,
 				304180F52ADC1325002AD2E3 /* OnboardingBackButton.swift in Sources */,
+				3052401A2ADE1299008FCD14 /* String+.swift in Sources */,
 				305240182ADD73EB008FCD14 /* SexClassification.swift in Sources */,
 				304180FC2ADCC9ED002AD2E3 /* SetupCompleteView.swift in Sources */,
 			);

--- a/Hamsters/Hamsters/Extensions/String+.swift
+++ b/Hamsters/Hamsters/Extensions/String+.swift
@@ -1,0 +1,14 @@
+//
+//  String+.swift
+//  Hamsters
+//
+//  Created by Chaeeun Shin on 10/17/23.
+//
+
+import SwiftUI
+
+extension String {
+    func trim() -> String {
+        return self.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Hamsters/Hamsters/Scenes/Onboarding/NicknameSetView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/NicknameSetView.swift
@@ -45,6 +45,8 @@ struct NicknameSetView: View {
                         focusField = true
                     }
                     .onChange(of: nickname) { _ in
+                        // 공백 제거
+                        nickname = nickname.trim()
                         if nickname.count == 0 {
                             isActiveNext = false
                         } else {

--- a/Hamsters/Hamsters/Scenes/Onboarding/NicknameSetView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/NicknameSetView.swift
@@ -83,6 +83,11 @@ struct NicknameSetView: View {
                     OnboardingBackButton(pageNumber: $pageNumber)
                 }
             }
+            .onAppear {
+                if nickname != "" {
+                    isActiveNext = true
+                }
+            }
         }
     }
 }

--- a/Hamsters/Hamsters/Scenes/Onboarding/OnboardingView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/OnboardingView.swift
@@ -40,7 +40,6 @@ struct OnboardingView: View {
             case 4:
                 SmokingSetView(pageNumber: $pageNumber, status: $status)
                     .onDisappear {
-                        print(status?.rawValue.description ?? "non")
                         storedSmoking = status?.rawValue ?? false
                     }
             case 5:

--- a/Hamsters/Hamsters/Scenes/Onboarding/SexSetView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/SexSetView.swift
@@ -90,6 +90,11 @@ struct SexSetView: View {
                     OnboardingBackButton(pageNumber: $pageNumber)
                 }
             }
+            .onAppear {
+                if selectedSex != nil {
+                    isActiveNext = true
+                }
+            }
         }
     }
 }

--- a/Hamsters/Hamsters/Scenes/Onboarding/SmokingSetView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/SmokingSetView.swift
@@ -64,6 +64,11 @@ struct SmokingSetView: View {
                     OnboardingBackButton(pageNumber: $pageNumber)
                 }
             }
+            .onAppear {
+                if status != nil {
+                    isActiveNext = true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #10 

## ✨ 작업 내용
- 온보딩 과정 중 앞뒤로 이동시 다음 버튼이 활성화 되도록 하였습니다
- 닉네임에 공백 입력이 불가능하도록 처리하였습니다


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
