### PR TITLE
[Feat/#38] 온보딩 디테일 수정(성별, 흡연)

### DIFF
--- a/Hamsters/Hamsters.xcodeproj/project.pbxproj
+++ b/Hamsters/Hamsters.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		300E8E992AF9D8CA001728FE /* ProgressBarAndTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300E8E982AF9D8CA001728FE /* ProgressBarAndTitle.swift */; };
 		30151F432AE3AD590036B60D /* SmokingAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30151F422AE3AD590036B60D /* SmokingAmount.swift */; };
 		30151F452AE3AE850036B60D /* DrinkCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30151F442AE3AE850036B60D /* DrinkCheckView.swift */; };
 		30151F472AE3AF060036B60D /* DrinkAmount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30151F462AE3AF060036B60D /* DrinkAmount.swift */; };
@@ -67,6 +68,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		300E8E982AF9D8CA001728FE /* ProgressBarAndTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarAndTitle.swift; sourceTree = "<group>"; };
 		30151F422AE3AD590036B60D /* SmokingAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokingAmount.swift; sourceTree = "<group>"; };
 		30151F442AE3AE850036B60D /* DrinkCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkCheckView.swift; sourceTree = "<group>"; };
 		30151F462AE3AF060036B60D /* DrinkAmount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkAmount.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 				304180E62ADAC9D7002AD2E3 /* OnboardingNextButton.swift */,
 				304180F42ADC1325002AD2E3 /* OnboardingBackButton.swift */,
 				304180F02ADBCA6E002AD2E3 /* OnboardingProgressBar.swift */,
+				300E8E982AF9D8CA001728FE /* ProgressBarAndTitle.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 				305240182ADD73EB008FCD14 /* SexClassification.swift in Sources */,
 				307B7D6F2AE424A2007CB7F5 /* MedicationView.swift in Sources */,
 				304180FC2ADCC9ED002AD2E3 /* SetupCompleteView.swift in Sources */,
+				300E8E992AF9D8CA001728FE /* ProgressBarAndTitle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Hamsters/Hamsters/Scenes/Onboarding/Components/ProgressBarAndTitle.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/Components/ProgressBarAndTitle.swift
@@ -1,0 +1,34 @@
+//
+//  ProgressBarAndTitle.swift
+//  Hamsters
+//
+//  Created by Chaeeun Shin on 11/7/23.
+//
+
+// 온보딩 통합때 사용 예정
+
+import SwiftUI
+
+struct ProgressBarAndTitle: View {
+    @Binding var pageNumber: Int
+    let totalPage: Double
+    let title: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ProgressView(value: Double(pageNumber), total: totalPage)
+                .tint(.thoNavy)
+                .padding(.vertical, 16)
+            
+            Text(title)
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .padding(.bottom, 16)
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+#Preview {
+    ProgressBarAndTitle(pageNumber: .constant(3), totalPage: 10, title: "성별을 선택해주세요")
+}

--- a/Hamsters/Hamsters/Scenes/Onboarding/SexSetView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/SexSetView.swift
@@ -70,7 +70,7 @@ struct SexSetView: View {
                                 .font(.title)
                                 .foregroundStyle(isMemopause ? .thoNavy : Color.secondary)
                             
-                            Text("페경 여부")
+                            Text("저는 월경을 하지 않아요!")
                                 .font(.body)
                                 .foregroundStyle(Color.primary)
                         }

--- a/Hamsters/Hamsters/Scenes/Onboarding/SmokingSetView.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/SmokingSetView.swift
@@ -18,7 +18,7 @@ struct SmokingSetView: View {
                 OnboardingProgressBar(pageNumber: $pageNumber)
                 
                 Group {
-                    Text("흡연 중 이신가요?")
+                    Text("흡연중이신가요?")
                         .font(.largeTitle)
                         .fontWeight(.bold)
                         .padding(.bottom, 45)


### PR DESCRIPTION
## 📌 관련 이슈
close #38 

## ✨ 작업 내용
- 온보딩 화면 중 성별, 흡연 여부와 관련된 내용을 수정했습니다.
- 온보딩 뷰 통합 시 사용할 컴포넌트(프로그래스바 + 타이틀)를 생성했습니다.


\* 패딩과 같은 디자인 사항은 온보딩 뷰 통합시 적용할 예정입니다.

## 📸 스크린샷(선택)
<img width="466" alt="image" src="https://github.com/SSOTARTUP/ADHD/assets/96675556/0695a54f-b283-46f7-b6c2-46cc7378a0ba">