### PR TITLE
[Fix/#74] 온보딩 - 컨디션 뷰에서 상태 체크 시 다음 말풍선이 나오는 방식 변경

### DIFF
--- a/Hamsters/Hamsters/Models/Record/ConditionModel.swift
+++ b/Hamsters/Hamsters/Models/Record/ConditionModel.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-struct ConditionModel :Identifiable ,Equatable{
+struct ConditionModel: Identifiable ,Equatable{
     var id = UUID()
-    let sender:Sender
-    var text:String?
-    var conditionType:ConditionType?
-    var answer:Answer?
+    let sender: Sender
+    var text: String?
+    var conditionType: ConditionType?
+    var answer: Answer?
     
     enum Sender {
         case computer

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/DailyRecord/Components/UserChat.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/DailyRecord/Components/UserChat.swift
@@ -125,10 +125,14 @@ struct UserChat: View {
 extension UserChat{
     func answerButtonClicked(answer:Answer){
         guard let type = conditionModel?.conditionType else { return }
-        viewModel.answer[type] = answer
-        
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
-            viewModel.add()
+        if viewModel.answer[type] == nil {
+            viewModel.answer[type] = answer
+            
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+                viewModel.add()
+            }
+        } else {
+            viewModel.answer[type] = answer
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
 온보딩 - 컨디션 뷰에서 상태 체크 시 다음 말풍선이 나오는 방식 변경
## ✨ 작업 내용
<!-- 과제에 대한 설명을 적어주세요 -->
 온보딩 - 컨디션 뷰에서 상태 체크 시 다음 말풍선이 나오는 방식 변경
## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
