### PR TITLE
[Feat/#105] 기록하기 메인뷰 캘린더 데이터-UI 연동

### DIFF
--- a/Hamsters/Hamsters/Extensions/Date.swift
+++ b/Hamsters/Hamsters/Extensions/Date.swift
@@ -113,7 +113,7 @@ extension DateFormatter {
     }
 }
 
-private func createKoKRFormatter() -> DateFormatter {
+func createKoKRFormatter() -> DateFormatter {
     let dateFormatter = DateFormatter()
     dateFormatter.locale = Locale(identifier: "ko_KR")
     dateFormatter.timeZone = TimeZone(abbreviation: "KST")

--- a/Hamsters/Hamsters/Extensions/String+.swift
+++ b/Hamsters/Hamsters/Extensions/String+.swift
@@ -21,3 +21,15 @@ extension String {
             .compactMap { DailyRecordPage(rawValue: $0) }
     }
 }
+
+extension String {
+    public func toDate() -> Date? {
+        let dateFormatter = createKoKRFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        if let date = dateFormatter.date(from: self) {
+            return date
+        } else {
+            return nil
+        }
+    }
+}

--- a/Hamsters/Hamsters/Models/Enums/UserDefaultsKey.swift
+++ b/Hamsters/Hamsters/Models/Enums/UserDefaultsKey.swift
@@ -16,6 +16,8 @@ enum UserDefaultsKey: String {
     case complete   // 설정 완료 - Bool
     case dailyRecordPage
     
+    case startDate
+    
     enum PageControl: String {
         case period
         case caffeine

--- a/Hamsters/Hamsters/Scenes/Onboarding/ViewModel/OnboardingViewModel.swift
+++ b/Hamsters/Hamsters/Scenes/Onboarding/ViewModel/OnboardingViewModel.swift
@@ -16,6 +16,8 @@ class OnboardingViewModel: ObservableObject {
     @AppStorage(UserDefaultsKey.smoking.rawValue) private var storedSmoking: Bool = false
     @AppStorage(UserDefaultsKey.complete.rawValue) private var setupComplete: Bool = false
     
+    @AppStorage(UserDefaultsKey.startDate.rawValue) private var startDate: String = Date().summaryWithTimeWithSecond
+    
     // 기록 페이지 구성
     @AppStorage(UserDefaultsKey.dailyRecordPage.rawValue) var dailyRecordPages: String = [
         DailyRecordPage.condition,
@@ -104,6 +106,8 @@ class OnboardingViewModel: ObservableObject {
         isOnDrink = true
         
         setupComplete = true
+        
+        startDate = Date().summaryWithTimeWithSecond
     }
 }
 

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordMainView.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordMainView.swift
@@ -13,7 +13,7 @@ struct RecordMainView: View {
         
     @State private var selectedDate = Date()
     @State private var isActiveSheet = false
-    @State private var isToday: IsToday = .today
+    @State private var dateStatus: DateStatus = .today
     
     @StateObject var viewModel = RecordMainViewModel()
     
@@ -49,7 +49,7 @@ struct RecordMainView: View {
                 }
                 .padding()
 
-                RecordWeeklyCalendar(selectedDate: $selectedDate, isToday: $isToday)
+                RecordWeeklyCalendar(selectedDate: $selectedDate, dateStatus: $dateStatus)
                     .padding(.top)
                     
                 Spacer()
@@ -60,7 +60,7 @@ struct RecordMainView: View {
                     .frame(maxHeight: 160)
                     .padding(.bottom, 28)
                 
-                RecordButton(status: isToday) {
+                RecordButton(status: dateStatus) {
                     isActiveSheet = true
                 }
                 .padding(.bottom, 28)
@@ -79,7 +79,7 @@ struct RecordMainView: View {
 extension RecordMainView {
     struct RecordWeeklyCalendar: View {
         @Binding var selectedDate: Date
-        @Binding var isToday: IsToday
+        @Binding var dateStatus: DateStatus
         @State private var weeklyHeight: CGFloat = 220.0
        
         var body: some View {
@@ -116,7 +116,7 @@ extension RecordMainView {
                 .padding(.horizontal, 22)
                 .frame(height: 80)
                 
-                WeeklyCalendarView(selectedDate: $selectedDate, calendarHeight: $weeklyHeight, existLog: .constant(["2023-11-16", "2023-11-15", "2023-11-13", "2023-11-11", "2023-11-9"]), isToday: $isToday)
+                WeeklyCalendarView(selectedDate: $selectedDate, calendarHeight: $weeklyHeight, existLog: .constant(["2023-11-16", "2023-11-15", "2023-11-13", "2023-11-11", "2023-11-9"]), dateStatus: $dateStatus)
                     .frame(width: screenBounds().width - 38, height: weeklyHeight)
             }
         }
@@ -125,7 +125,7 @@ extension RecordMainView {
     
     
     struct RecordButton: View {
-        let status: IsToday
+        let status: DateStatus
         var action: () -> Void
         
         var body: some View {
@@ -148,7 +148,7 @@ extension RecordMainView {
 }
 
 
-enum IsToday {
+enum DateStatus {
     case past
     case today
     case future

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordMainView.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordMainView.swift
@@ -10,12 +10,9 @@ import CoreData
 
 struct RecordMainView: View {
     @Environment(\.safeAreaInsets) private var safeAreaInsets
-        
-    @State private var selectedDate = Date()
-    @State private var isActiveSheet = false
-    @State private var dateStatus: DateStatus = .today
-    
+
     @StateObject var viewModel = RecordMainViewModel()
+    @State private var isActiveSheet = false
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -40,16 +37,17 @@ struct RecordMainView: View {
             // MARK: 헤더
             VStack(spacing: 0) {
                 HStack {
-                    Text(selectedDate.monthAndDay)
+                    Text(viewModel.selectedDate.monthAndDay)
                     
-                    if selectedDate.basic == Date().basic {
+                    if viewModel.selectedDate.basic == Date().basic {
                         Text("오늘")
                             .fontWeight(.semibold)
                     }
                 }
                 .padding()
 
-                RecordWeeklyCalendar(selectedDate: $selectedDate, dateStatus: $dateStatus)
+                RecordWeeklyCalendar()
+                    .environmentObject(viewModel)
                     .padding(.top)
                     
                 Spacer()
@@ -60,7 +58,7 @@ struct RecordMainView: View {
                     .frame(maxHeight: 160)
                     .padding(.bottom, 28)
                 
-                RecordButton(status: dateStatus) {
+                RecordButton(status: viewModel.dateStatus) {
                     isActiveSheet = true
                 }
                 .padding(.bottom, 28)
@@ -78,8 +76,7 @@ struct RecordMainView: View {
 
 extension RecordMainView {
     struct RecordWeeklyCalendar: View {
-        @Binding var selectedDate: Date
-        @Binding var dateStatus: DateStatus
+        @EnvironmentObject var viewModel: RecordMainViewModel
         @State private var weeklyHeight: CGFloat = 220.0
        
         var body: some View {
@@ -87,36 +84,36 @@ extension RecordMainView {
                 HStack {
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "월" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "월" ? 1 : 0)
 
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "화" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "화" ? 1 : 0)
                     
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "수" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "수" ? 1 : 0)
                     
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "목" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "목" ? 1 : 0)
                     
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "금" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "금" ? 1 : 0)
                     
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "토" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "토" ? 1 : 0)
                     
                     RoundedRectangle(cornerRadius: 40)
                         .stroke(Color.thoNavy)
-                        .opacity(selectedDate.basicWithDay.suffix(1) == "일" ? 1 : 0)
+                        .opacity(viewModel.selectedDate.basicWithDay.suffix(1) == "일" ? 1 : 0)
                 }
                 .padding(.horizontal, 22)
                 .frame(height: 80)
                 
-                WeeklyCalendarView(selectedDate: $selectedDate, calendarHeight: $weeklyHeight, existLog: .constant(["2023-11-16", "2023-11-15", "2023-11-13", "2023-11-11", "2023-11-9"]), dateStatus: $dateStatus)
+                WeeklyCalendarView(calendarHeight: $weeklyHeight)
                     .frame(width: screenBounds().width - 38, height: weeklyHeight)
             }
         }

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordMainView.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordMainView.swift
@@ -17,7 +17,6 @@ struct RecordMainView: View {
     var body: some View {
         ZStack(alignment: .top) {
             // MARK: 배경
-
             Color.sky
             
             VStack {
@@ -58,7 +57,7 @@ struct RecordMainView: View {
                     .frame(maxHeight: 160)
                     .padding(.bottom, 28)
                 
-                RecordButton(status: viewModel.dateStatus) {
+                RecordButton(status: viewModel.recordStatus) {
                     isActiveSheet = true
                 }
                 .padding(.bottom, 28)
@@ -122,7 +121,7 @@ extension RecordMainView {
     
     
     struct RecordButton: View {
-        let status: DateStatus
+        let status: RecordStatus
         var action: () -> Void
         
         var body: some View {
@@ -139,53 +138,59 @@ extension RecordMainView {
                     .padding(.horizontal, 61)
                     .shadow(color: .black.opacity(status.buttonShadowOpacity), radius: 2, x: 0, y: 4)
             }
-            .disabled(status != .today)
+            .disabled(status.buttonDisabled)
         }
     }
 }
 
 
-enum DateStatus {
-    case past
-    case today
-    case future
-        var buttonTitle: String {
-            switch self {
-            case .past:
-                "과거의 기록은 추가할 수 없어요!"
-            case .today:
-                "오늘의 상태 추가하기"
-            case .future:
-                "미래의 기록은 추가할 수 없어요!"
-            }
+enum RecordStatus {
+    case noRecord
+    case record
+    
+    var buttonDisabled: Bool {
+        switch self {
+        case .noRecord: false
+        case .record: true
         }
+    }
+    
+    var buttonTitle: String {
+        switch self {
+        case .noRecord:
+            "오늘의 상태 추가하기"
+            
+        case .record:
+            "오늘의 기록 완료!"
+        }
+    }
         
-        var buttonBackgroundColor: Color {
-            switch self {
-            case .today:
-                Color.thoNavy
-            default:
-                Color.thoDisabled
-            }
+    var buttonBackgroundColor: Color {
+        switch self {
+        case .noRecord:
+            Color.thoNavy
+        case .record:
+            Color.thoDisabled
         }
-        
-        var buttonTextColor: Color {
-            switch self {
-            case .today:
-                Color.white
-            default:
-                Color.thoNavy
-            }
+    }
+    
+    var buttonTextColor: Color {
+        switch self {
+        case .noRecord:
+            Color.white
+        case .record:
+            Color.thoNavy
         }
-        
-        var buttonShadowOpacity: Double {
-            switch self {
-            case .today:
-                0.25
-            default:
-                0.0
-            }
+    }
+    
+    var buttonShadowOpacity: Double {
+        switch self {
+        case .noRecord:
+            0.25
+        case .record:
+            0.0
         }
+    }
 }
 
 #Preview {

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
@@ -10,12 +10,9 @@ import UIKit
 import FSCalendar
 
 struct WeeklyCalendarView: UIViewRepresentable {
-    @Binding var selectedDate: Date
+    @EnvironmentObject var viewModel: RecordMainViewModel
     @Binding var calendarHeight: CGFloat
-    @Binding var existLog: [String]
-    @Binding var dateStatus: DateStatus
-    @State private var isFirstLoad = true
-    
+
     func makeUIView(context: Context) -> FSCalendar {
         configureCalendar()
     }
@@ -30,7 +27,7 @@ struct WeeklyCalendarView: UIViewRepresentable {
     
     // 유킷 -> 스유
     func makeCoordinator() -> Coordinator {
-        Coordinator(selectedDate: $selectedDate, calendarHeight: $calendarHeight, existLog: $existLog, dateStatus: $dateStatus)
+        Coordinator(selectedDate: $viewModel.selectedDate, calendarHeight: $calendarHeight, existLog: $viewModel.datesOnRecord, dateStatus: $viewModel.dateStatus)
     }
     
     class Coordinator: NSObject, FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
@@ -149,6 +146,6 @@ extension WeeklyCalendarView {
 }
 
 #Preview {
-    WeeklyCalendarView(selectedDate: .constant(Date()), calendarHeight: .constant(300), existLog: .constant(["2023-11-16", "2023-11-15", "2023-11-13", "2023-11-11", "2023-11-9"]), dateStatus: .constant(.today))
-        .border(.red)
+    WeeklyCalendarView(calendarHeight: .constant(300))
+        .environmentObject(RecordMainViewModel())
 }

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
@@ -27,20 +27,18 @@ struct WeeklyCalendarView: UIViewRepresentable {
     
     // 유킷 -> 스유
     func makeCoordinator() -> Coordinator {
-        Coordinator(selectedDate: $viewModel.selectedDate, calendarHeight: $calendarHeight, existLog: $viewModel.datesOnRecord, dateStatus: $viewModel.dateStatus)
+        Coordinator(selectedDate: $viewModel.selectedDate, calendarHeight: $calendarHeight, existLog: $viewModel.datesOnRecord)
     }
     
     class Coordinator: NSObject, FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
         @Binding var selectedDate: Date
         @Binding var calendarHeight: CGFloat
         @Binding var existLog: [String]
-        @Binding var dateStatus: DateStatus
         
-        init(selectedDate: Binding<Date>, calendarHeight: Binding<CGFloat>, existLog: Binding<[String]>, dateStatus: Binding<DateStatus>) {
+        init(selectedDate: Binding<Date>, calendarHeight: Binding<CGFloat>, existLog: Binding<[String]>) {
             self._selectedDate = selectedDate
             self._calendarHeight = calendarHeight
             self._existLog = existLog
-            self._dateStatus = dateStatus
         }
         
         func calendar(_ calendar: FSCalendar,
@@ -50,14 +48,6 @@ struct WeeklyCalendarView: UIViewRepresentable {
                 guard let self = self else { return }
                 
                 selectedDate = date
-                
-                if date.basicDash > Date.now.basicDash {
-                    dateStatus = .future
-                } else if date.basicDash < Date.now.basicDash {
-                    dateStatus = .past
-                } else {
-                    dateStatus = .today
-                }
             }
         }
         

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
@@ -25,10 +25,7 @@ struct WeeklyCalendarView: UIViewRepresentable {
         uiView.delegate = context.coordinator
         uiView.dataSource = context.coordinator
         
-        if isFirstLoad {
-            uiView.reloadData()
-            isFirstLoad = false
-        }
+        uiView.reloadData()
     }
     
     // 유킷 -> 스유

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/RecordWeeklyCalendar.swift
@@ -13,7 +13,7 @@ struct WeeklyCalendarView: UIViewRepresentable {
     @Binding var selectedDate: Date
     @Binding var calendarHeight: CGFloat
     @Binding var existLog: [String]
-    @Binding var isToday: IsToday
+    @Binding var dateStatus: DateStatus
     @State private var isFirstLoad = true
     
     func makeUIView(context: Context) -> FSCalendar {
@@ -30,20 +30,20 @@ struct WeeklyCalendarView: UIViewRepresentable {
     
     // 유킷 -> 스유
     func makeCoordinator() -> Coordinator {
-        Coordinator(selectedDate: $selectedDate, calendarHeight: $calendarHeight, existLog: $existLog, isToday: $isToday)
+        Coordinator(selectedDate: $selectedDate, calendarHeight: $calendarHeight, existLog: $existLog, dateStatus: $dateStatus)
     }
     
     class Coordinator: NSObject, FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
         @Binding var selectedDate: Date
         @Binding var calendarHeight: CGFloat
         @Binding var existLog: [String]
-        @Binding var isToday: IsToday
+        @Binding var dateStatus: DateStatus
         
-        init(selectedDate: Binding<Date>, calendarHeight: Binding<CGFloat>, existLog: Binding<[String]>, isToday: Binding<IsToday>) {
+        init(selectedDate: Binding<Date>, calendarHeight: Binding<CGFloat>, existLog: Binding<[String]>, dateStatus: Binding<DateStatus>) {
             self._selectedDate = selectedDate
             self._calendarHeight = calendarHeight
             self._existLog = existLog
-            self._isToday = isToday
+            self._dateStatus = dateStatus
         }
         
         func calendar(_ calendar: FSCalendar,
@@ -55,11 +55,11 @@ struct WeeklyCalendarView: UIViewRepresentable {
                 selectedDate = date
                 
                 if date.basicDash > Date.now.basicDash {
-                    isToday = .future
+                    dateStatus = .future
                 } else if date.basicDash < Date.now.basicDash {
-                    isToday = .past
+                    dateStatus = .past
                 } else {
-                    isToday = .today
+                    dateStatus = .today
                 }
             }
         }
@@ -108,6 +108,9 @@ struct WeeklyCalendarView: UIViewRepresentable {
             Date()
         }
         
+        func minimumDate(for calendar: FSCalendar) -> Date {
+            Date()
+        }
     }
 }
 
@@ -146,6 +149,6 @@ extension WeeklyCalendarView {
 }
 
 #Preview {
-    WeeklyCalendarView(selectedDate: .constant(Date()), calendarHeight: .constant(300), existLog: .constant(["2023-11-16", "2023-11-15", "2023-11-13", "2023-11-11", "2023-11-9"]), isToday: .constant(.today))
+    WeeklyCalendarView(selectedDate: .constant(Date()), calendarHeight: .constant(300), existLog: .constant(["2023-11-16", "2023-11-15", "2023-11-13", "2023-11-11", "2023-11-9"]), dateStatus: .constant(.today))
         .border(.red)
 }

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/viewModel/RecordMainViewModel.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/viewModel/RecordMainViewModel.swift
@@ -11,6 +11,7 @@ import CoreData
 
 class RecordMainViewModel: NSObject, ObservableObject {
     @Published var medicineSchedule: [MedicineSchedule] = []
+    @Published var selectedDat: Date = Date()
 
     private let takensController: NSFetchedResultsController<Takens>
     private let medicinesController: NSFetchedResultsController<Medicines>

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/viewModel/RecordMainViewModel.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/viewModel/RecordMainViewModel.swift
@@ -12,11 +12,10 @@ import CoreData
 class RecordMainViewModel: NSObject, ObservableObject {
     @Published var medicineSchedule: [MedicineSchedule] = []
     @Published var datesOnRecord: [String] = []
+    @Published var recordStatus: RecordStatus = .noRecord
     
-    // 캘린더 관련 변수
     @Published var selectedDate: Date = Date()
-    @Published var dateStatus: DateStatus = .today
-    
+
     private let startDateString = UserDefaults.standard.string(forKey: UserDefaultsKey.startDate.rawValue)
 
     private let takensController: NSFetchedResultsController<Takens>
@@ -27,7 +26,7 @@ class RecordMainViewModel: NSObject, ObservableObject {
     override init() {
         let fetchTakensRequest: NSFetchRequest<Takens> = Takens.fetchRequest()
         fetchTakensRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Takens.date, ascending: true)]
-        let startDate = Calendar.current.startOfDay(for: Date())
+//        let startDate = Calendar.current.startOfDay(for: Date())
 //        fetchTakensRequest.predicate = NSPredicate(format: "date == %@", startDate as CVarArg)
         
         takensController = NSFetchedResultsController(
@@ -105,6 +104,10 @@ extension RecordMainViewModel {
             datesOnRecord = recordDatesDict.compactMap{ $0.0.basicDash }
         } else {
             datesOnRecord = []
+        }
+        
+        if datesOnRecord.contains(today.basicDash) {
+            recordStatus = .record
         }
     }
     

--- a/Hamsters/Hamsters/Scenes/Tab/RecordTab/viewModel/RecordMainViewModel.swift
+++ b/Hamsters/Hamsters/Scenes/Tab/RecordTab/viewModel/RecordMainViewModel.swift
@@ -11,7 +11,13 @@ import CoreData
 
 class RecordMainViewModel: NSObject, ObservableObject {
     @Published var medicineSchedule: [MedicineSchedule] = []
-    @Published var selectedDat: Date = Date()
+    @Published var datesOnRecord: [String] = []
+    
+    // 캘린더 관련 변수
+    @Published var selectedDate: Date = Date()
+    @Published var dateStatus: DateStatus = .today
+    
+    private let startDateString = UserDefaults.standard.string(forKey: UserDefaultsKey.startDate.rawValue)
 
     private let takensController: NSFetchedResultsController<Takens>
     private let medicinesController: NSFetchedResultsController<Medicines>
@@ -85,7 +91,21 @@ extension RecordMainViewModel {
             .sorted{ compareTimeOnly(date1: $0.settingTime, date2: $1.settingTime) }
         
         medicineSchedule = result
+        loadDates()
         print("update success")
+    }
+    
+    private func loadDates() {
+        let today = Date()
+        let startDate = Calendar.current.date(byAdding: .day, value: -6, to: today) ?? Date()   // 일주일치만 조회
+        
+        let recordDatesDict = DayRecordsManager.shared.fetchDayRecords(from: startDate, to: today)
+        
+        if let recordDatesDict = recordDatesDict {
+            datesOnRecord = recordDatesDict.compactMap{ $0.0.basicDash }
+        } else {
+            datesOnRecord = []
+        }
     }
     
     func takeMedicine(_ medicine: MedicineSchedule) {
@@ -93,7 +113,7 @@ extension RecordMainViewModel {
 
         let historyModel = HistoryModel(id: medicine.id, capacity: medicine.capacity, name: medicine.name, settingTime: medicine.settingTime, timeTaken: now, unit: medicine.unit)
     
-        let status = TakensManager.shared.updateHistory(date: now, historyModel: historyModel)
+        _ = TakensManager.shared.updateHistory(date: now, historyModel: historyModel)
     }
     
     func compareTimeOnly(date1: Date, date2: Date) -> Bool{


### PR DESCRIPTION
## 📌 관련 이슈
close #105 

## ✨ 작업 내용
- 기록하기 메인뷰 상단 캘린더 UI와 데이터 연동
- 데일리 기록 존재시 기록하기 버튼 비활성화

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
